### PR TITLE
Meta details

### DIFF
--- a/src/bbga/settings.py
+++ b/src/bbga/settings.py
@@ -52,7 +52,6 @@ INSTALLED_APPS = [
     'bbga_data',
     'corsheaders',
     'rest_framework',
-    'rest_framework_swagger',
     'django_filters',
     'health',
 ]
@@ -160,44 +159,8 @@ REST_FRAMEWORK = dict(
 )
 
 # SWAGGER
-
-swag_path = 'acc.api.data.amsterdam.nl/bbga/docs'
-
-if DEBUG:
-    swag_path = '127.0.0.1:8000/bbga/docs'
-
 SWAGGER_SETTINGS = {
-    'exclude_namespaces': [],
-    'api_version': '0.1',
-    'api_path': '/',
-
-    'enabled_methods': [
-        'get',
-    ],
-
-    'api_key': '',
     'USE_SESSION_AUTH': False,
-    'VALIDATOR_URL': None,
-
-    'is_authenticated': False,
-    'is_superuser': False,
-
-    'permission_denied_handler': None,
-    'resource_access_handler': None,
-
-    'protocol': 'https' if not DEBUG else '',
-    'base_path': swag_path,
-
-    'info': {
-        'contact': 'atlas.basisinformatie@amsterdam.nl',
-        'description': 'This is the BBGA API server.',
-        'license': 'license Not known yet.',
-        'licenseUrl': '://www.amsterdam.nl/stelselpedia/',
-        'termsOfServiceUrl': 'https://data.amsterdam.nl/terms/',
-        'title': 'BBGA',
-    },
-
-    'doc_expansion': 'list',
 }
 
 LOGSTASH_HOST = os.getenv('LOGSTASH_HOST', '127.0.0.1')

--- a/src/bbga/settings.py
+++ b/src/bbga/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.gis',
     'django.contrib.postgres',
     'django_extensions',
+    'drf_yasg',
     'datapunt_api',
     'bbga',
     'bbga_data',

--- a/src/bbga/urls.py
+++ b/src/bbga/urls.py
@@ -144,7 +144,7 @@ schema_view = get_schema_view(
         description="BBGA API",
         terms_of_service="https://data.amsterdam.nl/",
         contact=openapi.Contact(email="datapunt@amsterdam.nl"),
-        license=openapi.License(name="CC0 1.0 Universal"),
+        license=openapi.License(name="license Not known yet."),
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),

--- a/src/bbga/urls.py
+++ b/src/bbga/urls.py
@@ -125,11 +125,11 @@ bbga.add_api_view(
 )
 
 bbga.register(
-    r'meta', bbga_views.MetaViewSet, base_name='bbga/meta',
+    r'meta', bbga_views.MetaViewSet, base_name='meta',
 )
 
 bbga.register(
-    r'cijfers', bbga_views.CijfersViewSet, base_name='bbga/cijfers'
+    r'cijfers', bbga_views.CijfersViewSet, base_name='cijfers'
 )
 
 

--- a/src/bbga_data/serializers.py
+++ b/src/bbga_data/serializers.py
@@ -9,7 +9,7 @@ class BBGAMixin(rest.DataSetSerializerMixin):
 
 
 # list serializers
-class Meta(serializers.ModelSerializer):
+class MetaSerialiser(serializers.ModelSerializer):
     _display = rest.DisplayField()
 
     class Meta:
@@ -18,7 +18,6 @@ class Meta(serializers.ModelSerializer):
 
 
 class MetaDetail(BBGAMixin, rest.HALSerializer):
-    type = serializers.CharField(source='get_type_display')
     _display = rest.DisplayField()
 
     class Meta:
@@ -39,11 +38,11 @@ class Cijfers(serializers.ModelSerializer):
 
 
 class CijferDetail(BBGAMixin, rest.HALSerializer):
-    type = serializers.CharField(source='get_type_display')
     _display = rest.DisplayField()
 
     class Meta:
         model = models.Cijfers
+        fields = '__all__'
 
 
 class VariabelenSerializer(serializers.Serializer):

--- a/src/bbga_data/tests/tests.py
+++ b/src/bbga_data/tests/tests.py
@@ -1,5 +1,6 @@
 # Python
 import os
+import json
 from datetime import date
 
 from rest_framework.test import APITestCase
@@ -50,6 +51,24 @@ class BrowseDatasetsTestCase(APITestCase):
             self.assertNotEqual(
                 response.data['count'], 0,
                 'Wrong result count for {}'.format(url))
+
+    def test_details(self):
+        for url in self.datasets:
+            list_response = self.client.get('/{}/'.format(url))
+
+            first_result = json.loads(
+                list_response.content)['results'][0]['id']
+
+            response = self.client.get('/{}/{}/'.format(url, first_result))
+
+            self.assertEqual(
+                response.status_code, 200,
+                'Wrong response code for {}/{}'.format(url, first_result))
+
+            self.assertEqual(
+                response['Content-Type'],
+                'application/json',
+                'Wrong Content-Type for {}/{}'.format(url, first_result))
 
     def test_extra(self):
         for url in self.extra_sets:

--- a/src/bbga_data/views.py
+++ b/src/bbga_data/views.py
@@ -75,7 +75,7 @@ class MetaViewSet(rest.DatapuntViewSet):
     """
 
     queryset = models.Meta.objects.all().order_by('id')
-    serializer_class = serializers.Meta
+    serializer_class = serializers.MetaSerialiser
     serializer_detail_class = serializers.MetaDetail
     filter_backends = (DjangoFilterBackend,)
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,6 @@ django-cors-headers==2.4.0
 django-debug-toolbar==1.11
 django-extensions==2.1.4
 django-filter==2.0.0
-django-rest-swagger==2.2.0
 django-shotgun==0.2
 djangorestframework==3.9.1
 djangorestframework-csv==2.1.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -21,6 +21,7 @@ drf-amsterdam==0.1.8
 drf-extensions==0.4.0
 drf-hal-json==0.9.1
 drf-nested-fields==0.9.4
+drf-yasg==1.15.0
 factory-boy==2.11.1
 fake-factory==9999.9.9
 Faker==1.0.1


### PR DESCRIPTION
Gefixed Meta details view.

Gebruikt `drf_yasg` omdat Django Filters waren zichtbaar op Meta en Cijfers details schemas.