### PR TITLE
Drop  django-rest-framework-jwt requirement

### DIFF
--- a/src/bbga/urls.py
+++ b/src/bbga/urls.py
@@ -129,11 +129,11 @@ bbga.add_api_view(
 )
 
 bbga.register(
-    r'meta', bbga_views.MetaViewSet, base_name='meta',
+    r'meta', bbga_views.MetaViewSet, basename='meta',
 )
 
 bbga.register(
-    r'cijfers', bbga_views.CijfersViewSet, base_name='cijfers'
+    r'cijfers', bbga_views.CijfersViewSet, basename='cijfers'
 )
 
 

--- a/src/requirements-noversion.txt
+++ b/src/requirements-noversion.txt
@@ -12,7 +12,6 @@ django-extensions
 django-filter
 djangorestframework
 djangorestframework-gis
-djangorestframework-jwt
 django-rest-swagger
 django-shotgun
 drf-extensions

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,7 +14,6 @@ django-shotgun==0.2
 djangorestframework==3.11.2
 djangorestframework-csv==2.1.0
 djangorestframework-gis==0.14
-djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 drf-amsterdam==0.1.8
 drf-extensions==0.4.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -44,7 +44,7 @@ pyslack-real==0.6.0
 python-dateutil==2.7.5
 pytz==2018.9
 PyYAML==5.4
-requests==2.21.0
+requests==2.28.1
 simplejson==3.16.0
 six==1.12.0
 sphinx-me==0.3

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -19,7 +19,7 @@ drf-amsterdam==0.1.8
 drf-extensions==0.4.0
 drf-hal-json==0.9.1
 drf-nested-fields==0.9.4
-drf-yasg==1.15.0
+drf-yasg==1.20.0
 factory-boy==2.11.1
 fake-factory==9999.9.9
 Faker==1.0.1


### PR DESCRIPTION
This causes a dependency clash because it requires PyJWT < 2.0, which has vulns. I don't see where it's imported, so let's see if we can run without it.